### PR TITLE
Don't check hello

### DIFF
--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-jZkUKv2SV28wsM18tCqNxoCZmLxdYH2Idh9RLibH2yA=";
   };
 
-  doCheck = true;
-
   passthru.tests = {
     version = testers.testVersion { package = hello; };
 


### PR DESCRIPTION
A test to see whether a PR to the non-migrated files (a change to `pkgs/applications/misc/hello/default.nix`) will give a merge conflict once the files are migrated (where it should now go to `pkgs/unit/he/hello/pkg-fun.nix`).

Result: Nope :(

But: `git merge <default-branch>` and `git rebase <default-branch>` work locally without having to resolve any conflicts manually, so not too bad.